### PR TITLE
[user-service-2] Creación de la entidad User y DTOs asociados

### DIFF
--- a/user-service/src/main/java/com/busconnect/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/busconnect/userservice/UserServiceApplication.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @OpenAPIDefinition(
@@ -13,6 +15,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
                 description = "Microservicio para gestión de usuarios en BusConnect"
         )
 )
+@EnableScheduling
+@EnableJpaAuditing
 public class UserServiceApplication {
 
     public static void main(String[] args) {

--- a/user-service/src/main/java/com/busconnect/userservice/dto/request/CreateUserRequest.java
+++ b/user-service/src/main/java/com/busconnect/userservice/dto/request/CreateUserRequest.java
@@ -1,0 +1,31 @@
+package com.busconnect.userservice.dto.request;
+
+import com.busconnect.userservice.model.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateUserRequest {
+
+    @Email(message = "{email.invalid}")
+    @NotBlank(message = "{email.required}")
+    private String email;
+
+    @NotBlank(message = "{password.required}")
+    private String password;
+
+    @NotBlank(message = "{firstName.required}")
+    private String firstName;
+
+    @NotBlank(message = "{lastName.required}")
+    private String lastName;
+
+    private String phone;
+
+    @NotNull(message = "{role.required}")
+    private UserRole role;
+
+}

--- a/user-service/src/main/java/com/busconnect/userservice/dto/request/UpdateUserRequest.java
+++ b/user-service/src/main/java/com/busconnect/userservice/dto/request/UpdateUserRequest.java
@@ -1,0 +1,22 @@
+package com.busconnect.userservice.dto.request;
+
+import com.busconnect.userservice.model.UserRole;
+import jakarta.validation.constraints.Email;
+import lombok.Data;
+
+@Data
+public class UpdateUserRequest {
+
+    @Email(message = "{email.invalid}")
+    private String email;
+
+    private String password;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String phone;
+
+    private UserRole role;
+}

--- a/user-service/src/main/java/com/busconnect/userservice/dto/response/UserResponse.java
+++ b/user-service/src/main/java/com/busconnect/userservice/dto/response/UserResponse.java
@@ -1,0 +1,24 @@
+package com.busconnect.userservice.dto.response;
+
+import com.busconnect.userservice.model.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private UserRole role;
+    private Boolean active;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/user-service/src/main/java/com/busconnect/userservice/model/User.java
+++ b/user-service/src/main/java/com/busconnect/userservice/model/User.java
@@ -1,0 +1,65 @@
+package com.busconnect.userservice.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users", schema = "user_service")
+@Access(AccessType.FIELD)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Email(message = "{email.invalid}")
+    @NotBlank(message = "{email.required}")
+    @Column(nullable = false, unique = true, length = 254)
+    private String email;
+
+    @NotBlank(message = "{password.required}")
+    @Column(nullable = false, length = 255)
+    private String passwordHash;
+
+    @NotBlank(message = "{firstName.required}")
+    @Column(nullable = false, length = 255)
+    private String firstName;
+
+    @NotBlank(message = "{lastName.required}")
+    @Column(nullable = false, length = 255)
+    private String lastName;
+
+    @Column(length = 20)
+    private String phone;
+
+    @NotNull(message = "{role.required}")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
+}

--- a/user-service/src/main/java/com/busconnect/userservice/model/UserRole.java
+++ b/user-service/src/main/java/com/busconnect/userservice/model/UserRole.java
@@ -1,0 +1,7 @@
+package com.busconnect.userservice.model;
+
+public enum UserRole {
+    CUSTOMER,
+    COMPANY,
+    ADMIN
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -35,3 +35,10 @@ logging:
     com.busconnect.userservice: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+# Configuración para el manejo de idiomas
+spring:
+  messages:
+    basename: messages
+    encoding: UTF-8
+    fallback-to-system-locale: false

--- a/user-service/src/main/resources/messages.properties
+++ b/user-service/src/main/resources/messages.properties
@@ -1,0 +1,6 @@
+email.invalid=Invalid email address
+email.required=Email is required
+firstName.required=First name is required
+lastName.required=Last name is required
+role.required=Role is required
+password.required=Password is required


### PR DESCRIPTION
## 🧩 [user-service-2] Creación de la entidad User y DTOs asociados

### 💡 Descripción
Esta PR implementa la entidad principal `User` y los objetos de transferencia de datos (DTOs) necesarios para la gestión de usuarios en el microservicio **user-service**.

---

### 🔧 Cambios realizados
-  Creada la entidad `User` con los campos:
  - `id`, `email`, `password`, `firstName`, `lastName`, `phone`, `role`, `createdAt`, `updatedAt`, `active`
-  Añadido `UserRole` (enum) con los valores: `CUSTOMER`, `COMPANY`, `ADMIN`
-  Creado `UserResponse` para respuestas
-  Creado `CreateUserRequest` y `UpdateUserRequest` para registro y actualización
-  Añadidas validaciones con **Jakarta Bean Validation** (`@NotNull`, `@Email`, `@Size`, etc.)
-  Uso de **Lombok** para simplificar getters, setters y constructores
-  Anotaciones JPA aplicadas correctamente (`@Entity`, `@Table`, `@Column`, `@Enumerated`, etc.)

---

### 🧪 Criterios de aceptación
- [x] La entidad `User` se mapea correctamente con JPA  
- [x] Los DTOs se generan sin errores de compilación  
- [x] Las validaciones funcionan correctamente  
- [x] El código sigue el estándar de estilo del proyecto  

---

### 🔗 Issue relacionada
Closes #2
